### PR TITLE
Capitalize 'url' in 'Link URL' label

### DIFF
--- a/markdown/icpsr_study_schema.md
+++ b/markdown/icpsr_study_schema.md
@@ -2011,9 +2011,18 @@ This element is only meant to convey specific, known, geography. If there is a v
     {
         "number": 2,
         "name": "Northbound Restricted-Use Data"
-    },
+    }
+]
+```
+
+```json
+[
     {
         "number": 1,
+        "name": "Original File"
+    },
+    {
+        "number": 2,
         "name": "Replicate Weight File",
         "sda_note": "Please note that the replicate weights are needed to obtain accurate standard error estimates. Users are advised to download the data to use the replicate weights. Users should refer to the study description page or User Guide for further details regarding weights."
     }

--- a/markdown/icpsr_study_schema.md
+++ b/markdown/icpsr_study_schema.md
@@ -1,6 +1,6 @@
 # ICPSR Metadata Schema
 
-Last updated: November 30, 2023
+Last updated: December 01, 2023
 
 This is the metadata schema used to describe data collections at the Inter-university Consortium for Political and Social Research (ICPSR). These rules and definitions represent ICPSR's metadata practices and are intended to (a) assist ICPSR staff with metadata entry, and (b) help ICPSR users -- including data depositors and researchers accessing data -- understand how to use and interpret our metadata.
 
@@ -1986,6 +1986,15 @@ This element is only meant to convey specific, known, geography. If there is a v
 **Examples:** 
 
 ```json
+"Please note that the AABS provides estimates for 32 states. It also supplies arts participation estimates for 11 metropolitan areas. Users are encouraged to review the Data Collection Notes on the Study Description page for specific states and metropolitan areas."
+```
+
+```json
+"Please note that the replicate weights are needed to obtain accurate standard error estimates. Users are advised to download the data to use the replicate weights. Users should refer to the study description page or User Guide for further details regarding weights."
+```
+
+###### Complete Filesets Examples (with Subfields):
+```json
 [
     {
         "number": 1
@@ -2002,6 +2011,11 @@ This element is only meant to convey specific, known, geography. If there is a v
     {
         "number": 2,
         "name": "Northbound Restricted-Use Data"
+    },
+    {
+        "number": 1,
+        "name": "Replicate Weight File",
+        "sda_note": "Please note that the replicate weights are needed to obtain accurate standard error estimates. Users are advised to download the data to use the replicate weights. Users should refer to the study description page or User Guide for further details regarding weights."
     }
 ]
 ```

--- a/resources/generate_markdown_schema.py
+++ b/resources/generate_markdown_schema.py
@@ -107,7 +107,7 @@ def persist_cache(cache, temp_dir):
 
 def clean_label(label):
 
-    return label.replace('_', ' ').title().replace("To", "to").replace("Of", "of").replace("Id", "ID").replace("Doi", "Digital Object Identifier (DOI)").replace("IDentifier", "Identifier").replace("Sda ", "SDA ")
+    return label.replace('_', ' ').title().replace("To", "to").replace("Of", "of").replace("Id", "ID").replace("Doi", "Digital Object Identifier (DOI)").replace("IDentifier", "Identifier").replace("Sda ", "SDA ").replace(" Url", " URL")
 
 def check_write(line, fo, processed_lines, index="foo"):
     if isinstance(index, int):
@@ -388,11 +388,11 @@ def main():
                     check_write('For a machine-actionable copy of this information, please see the [JSON Schema version](https://github.com/ICPSR/metadata/blob/main/schema/icpsr_study_schema.json).\n\n## Metadata Elements: Overview\n\n', fo, processed_lines)
 
                 #check to see if this is the second 'example' in a given section--if so, change the heading so that it's clear this is a full example with all subfields 
-                elif line.startswith('**Examples:**'):
+                elif line.startswith('**Example'):
                     #Add one to our example count
                     example_count += 1
                     #if our count is now at 2 it means we have consecutive 'Example' sections under one heading. Adjust the label. If count is at one, just write the line to file-out.
-                    if example_count == 2:
+                    if example_count > 1:
                         processed_lines = check_write(f'###### Complete {current_element} Examples (with Subfields):', fo, processed_lines, index)
                     else:
                         processed_lines = check_write(line, fo, processed_lines, index)

--- a/schema/icpsr_study_schema.json
+++ b/schema/icpsr_study_schema.json
@@ -835,7 +835,8 @@
           "sda_note": {
             "description": "Additional information about the fileset for the purpose of helping online analysis users.",
             "type": "string",
-            "controlledVocab": "N/A"
+            "controlledVocab": "N/A",
+            "examples": []
           }
         },
         "required": ["number"],

--- a/schema/icpsr_study_schema.json
+++ b/schema/icpsr_study_schema.json
@@ -836,7 +836,10 @@
             "description": "Additional information about the fileset for the purpose of helping online analysis users.",
             "type": "string",
             "controlledVocab": "N/A",
-            "examples": []
+            "examples": [
+              "Please note that the AABS provides estimates for 32 states. It also supplies arts participation estimates for 11 metropolitan areas. Users are encouraged to review the Data Collection Notes on the Study Description page for specific states and metropolitan areas.",
+              "Please note that the replicate weights are needed to obtain accurate standard error estimates. Users are advised to download the data to use the replicate weights. Users should refer to the study description page or User Guide for further details regarding weights."
+            ]
           }
         },
         "required": ["number"],
@@ -858,6 +861,11 @@
           {
             "number": 2,
             "name": "Northbound Restricted-Use Data"
+          },
+          {
+            "number": 1,
+            "name": "Replicate Weight File",
+            "sda_note": "Please note that the replicate weights are needed to obtain accurate standard error estimates. Users are advised to download the data to use the replicate weights. Users should refer to the study description page or User Guide for further details regarding weights."
           }
         ]
       ]

--- a/schema/icpsr_study_schema.json
+++ b/schema/icpsr_study_schema.json
@@ -861,9 +861,15 @@
           {
             "number": 2,
             "name": "Northbound Restricted-Use Data"
-          },
+          }
+        ],
+        [
           {
             "number": 1,
+            "name": "Original File"
+          },
+          {
+            "number": 2,
             "name": "Replicate Weight File",
             "sda_note": "Please note that the replicate weights are needed to obtain accurate standard error estimates. Users are advised to download the data to use the replicate weights. Users should refer to the study description page or User Guide for further details regarding weights."
           }


### PR DESCRIPTION
Adjusted markdown generation script so that 'Url' is capitalized as 'URL' in labels. Also fixed issue with Filesets examples--had to pull in some SDA Note examples from DBInfo so that the 'Complete Fileset' example label would display properly.