### PR TITLE
Revise workflow to trigger deployment

### DIFF
--- a/.github/workflows/update_html.yaml
+++ b/.github/workflows/update_html.yaml
@@ -29,8 +29,25 @@ jobs:
         run: |
           python resources/run_mkdocs.py --source-dir $GITHUB_WORKSPACE
 
-      - name: Deploy to GitHub Pages
+      - name: Deploy to gh-pages
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./site
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: update_html  # Specify that this job depends on the completion of 'update_html'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: gh-pages
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
Hi, jay; our current GitHub Actions workflow successfully creates new HTML and pushes it to our 'gh-pages' branch, but fails to actually deploy the content to https://icpsr.github.io/metadata/. I just revised the workflow so that it *should* update the public portal (but, of course, I can't actually test it until we approve a merge request). Keeping my fingers crossed that this works!