### PR TITLE
Nij

### DIFF
--- a/markdown/icpsr_study_schema.md
+++ b/markdown/icpsr_study_schema.md
@@ -1,6 +1,6 @@
 # ICPSR Metadata Schema
 
-Last updated: January 24, 2024
+Last updated: January 29, 2024
 
 This is the metadata schema used to describe data collections at the Inter-university Consortium for Political and Social Research (ICPSR). These rules and definitions represent ICPSR's metadata practices and are intended to (a) assist ICPSR staff with metadata entry, and (b) help ICPSR users -- including data depositors and researchers accessing data -- understand how to use and interpret our metadata.
 
@@ -1576,8 +1576,6 @@ The textual description should not simply restate the time period in words. For 
 
 **Usage Notes:** Weight includes any information about weighting variables in the data, as well as any other weight information provided by the Principal Investigator. If a weighting formula or coefficient was developed, provide this formula, define its elements, and indicate how the formula is applied to the data. It is acceptable to summarize information contained in documentation and refer users to that documentation for more information.
 
-**ICPSR Input Guidance:** For National Institute of Justice (NIJ) studies, 'Not applicable.' should be used if no information is available. For all other archives, this element is optional.
-
 **Examples:** 
 
 ```json
@@ -1606,8 +1604,6 @@ The textual description should not simply restate the time period in words. For 
 
 **Usage Notes:** Only applicable if the data were collected with a survey instrument and the response rates are provided.
 
-**ICPSR Input Guidance:** For National Institute of Justice (NIJ) studies, the phrase 'Not available' is used when no information is available and the phrase 'Not applicable' is used if Response Rates does not apply. For all other archives this element is optional.
-
 **Examples:** 
 
 ```json
@@ -1635,8 +1631,6 @@ The textual description should not simply restate the time period in words. For 
 **Controlled Vocabulary:** N/A
 
 **Usage Notes:** The inclusion of a common scale should be identified in the documentation associated with this dataset and confirmed by variable names or labels. The scales can be cited either as a list or described in full sentences. If the questionnaire used has a finite list of responses (e.g., 'Always, Sometimes, Rarely, Never' or Strongly Agree, Agree, Disagree, Strongly Disagree'), it is acceptable for this element to note 'A Likert-type scale was used,' or 'Several Likert-type scales were used.' However, it is not required to note Likart-type scales in situations where only such scales were used, given their ubiquity.  
-
-**ICPSR Input Guidance:** For National Institute of Justice (NIJ) studies, if there is no indication that scales are used, enter 'None' in this element. For all other archives, this element is optional.
 
 **Examples:** 
 
@@ -1706,9 +1700,7 @@ If the data do not include a geographic variable by which the data can be analyz
 
 This element is only meant to convey specific, known, geography. If there is a variable indicating which testing site a survey was taken at, but the locations of the testing sites were masked by the PI, this element is likely not indicated.  
 
-**ICPSR Input Guidance:** For National Institute of Justice (NIJ) studies, enter 'None' if no geographic variables are present. For all other archives, this element is optional.
-
-The following is a non-exhaustive list of potential entries: census tract, city, congressional district, Core-Based Statistical Area (CBSA), country, county, Federal Court District, FIPS code, jurisdiction, neighborhood, school district, state, ZIP code.
+**ICPSR Input Guidance:** The following is a non-exhaustive list of potential entries: census tract, city, congressional district, Core-Based Statistical Area (CBSA), country, county, Federal Court District, FIPS code, jurisdiction, neighborhood, school district, state, ZIP code.
 
 **Examples:** 
 

--- a/markdown/version_history.md
+++ b/markdown/version_history.md
@@ -3,3 +3,4 @@
 | Date | Version | Note |
 |------|---------|------|
 | Oct. 30, 2023 | v1 | Initial release and publication of the ICPSR Metadata Documentation Portal. |
+| Jan. 29, 2024 | v2 | Removed guidance regarding null entries for National Institute of Justice studies. Several fields previously required "None" when otherwise a field would be left blank. It was confirmed with the project managers this is no longer necessary NACJD-wide. |

--- a/schema/icpsr_study_schema.json
+++ b/schema/icpsr_study_schema.json
@@ -677,7 +677,6 @@
       "type": "string",
       "controlledVocab": "N/A",
       "usageNotes": "Weight includes any information about weighting variables in the data, as well as any other weight information provided by the Principal Investigator. If a weighting formula or coefficient was developed, provide this formula, define its elements, and indicate how the formula is applied to the data. It is acceptable to summarize information contained in documentation and refer users to that documentation for more information.",
-      "icpsrGuidance": "For National Institute of Justice (NIJ) studies, 'Not applicable.' should be used if no information is available. For all other archives, this element is optional.",
       "examples": [
         "A weight variable with two implied decimal places has been included and must be used in any analysis.",
         "Both the TransPop and Cisgender datasets have the same variable named WEIGHT as the weighting variable. The combination datasets have a set of three weight variables (WEIGHT_TRANSPOP, WEIGHT_CISGENDER, WEIGHT_CISGENDER_TRANSPOP). The results will be representative of the sample when the weight is applied. Pages 41 and 42 of the user guide contain instructions that detail how to apply the final sample weight using Stata or SPSS.",
@@ -689,7 +688,6 @@
       "type": "string",
       "controlledVocab": "N/A",
       "usageNotes": "Only applicable if the data were collected with a survey instrument and the response rates are provided.",
-      "icpsrGuidance": "For National Institute of Justice (NIJ) studies, the phrase 'Not available' is used when no information is available and the phrase 'Not applicable' is used if Response Rates does not apply. For all other archives this element is optional.",
       "examples": [
         "The overall response rate for this survey was 20.22%; 72.6% for existing panelists and 10.4% for new panelists, using AAPOR Response Rate 1.",
         "The response rate for the pre-election interview was 55.8 percent (66.5 percent for the Panel and 35.2 percent for the Fresh Cross). The response rate for the post-election interview was 89.1 (90.1 percent for the Panel and 85.2 percent for the Fresh Cross).",
@@ -700,7 +698,6 @@
       "description": "Any commonly known scale used to collect data for the data collection (e.g., psychological scales such as MMPI and CPI, or occupational scales such as the Census Occupational Codes).",
       "type": "string",
       "controlledVocab": "N/A",
-      "icpsrGuidance": "For National Institute of Justice (NIJ) studies, if there is no indication that scales are used, enter 'None' in this element. For all other archives, this element is optional.",
       "$ref": "https://schemas.icpsr.umich.edu/schema/yaml/scale?version=v1",
       "examples": [
         ["The baseline data collection included one scale - the CES-D index for maternal depression [Cole, J. C., Rabin, A. S., Smith, T. L., and Kaufman, A. S. (2004). Development and validation of a Rasch-derived CES-D short form. Psychological assessment, 16(4), 360]. All scales used for outcomes at ages 1 through 3 are listed in Appendix Tables 1 and 2 in the User Guide. Please refer to the User Guide and P.I. Codebook, available under the 'Data and Documentation' tab, for details."],

--- a/schema/yaml/smallest_geographic_unit.yaml
+++ b/schema/yaml/smallest_geographic_unit.yaml
@@ -8,6 +8,4 @@
 
     This element is only meant to convey specific, known, geography. If there is a variable indicating which testing site a survey was taken at, but the locations of the testing sites were masked by the PI, this element is likely not indicated.
   icpsrGuidance: |
-    For National Institute of Justice (NIJ) studies, enter 'None' if no geographic variables are present. For all other archives, this element is optional.
-
     The following is a non-exhaustive list of potential entries: census tract, city, congressional district, Core-Based Statistical Area (CBSA), country, county, Federal Court District, FIPS code, jurisdiction, neighborhood, school district, state, ZIP code.


### PR DESCRIPTION
Per email chain with NACJD PMs, removed guidance requiring "none" or similar for null entries in four fields that previously required them. Updated change log.