### PR TITLE
Update external source id internal guidance

### DIFF
--- a/markdown/icpsr_study_schema.md
+++ b/markdown/icpsr_study_schema.md
@@ -1,6 +1,6 @@
 # ICPSR Metadata Schema
 
-Last updated: June 27, 2024
+Last updated: June 28, 2024
 
 This is the metadata schema used to describe data collections at the Inter-university Consortium for Political and Social Research (ICPSR). These rules and definitions represent ICPSR's metadata practices and are intended to (a) assist ICPSR staff with metadata entry, and (b) help ICPSR users -- including data depositors and researchers accessing data -- understand how to use and interpret our metadata.
 
@@ -893,7 +893,7 @@ If a non-ICPSR distributor is necessary, please confirm the standards with the M
 
 **Controlled Vocabulary:** N/A
 
-**ICPSR Input Guidance:** This is an internal ICPSR element that is not publicly displayed.
+**ICPSR Input Guidance:** This is an internal ICPSR element that is not publicly displayed. An External Source ID consists of: an ICPSR-defined source organization code, a colon, and a Depositor-supplied ID.
 
 **Examples:** 
 

--- a/markdown/version_history.md
+++ b/markdown/version_history.md
@@ -7,3 +7,4 @@
 | Mar. 22, 2024 | v3 | Added 'study number' and distributor 'order' elements to the schema to address earlier oversight. |
 | June 18, 2024 | v4 | Revised 'principal investigator' element to better reflect its use in ICPSR systems. |
 | June 27, 2024 | v5 | Updated internal guidance for the 'funding purpose' element. |
+| June 28, 2024 | v6 | Updated internal guidance for the 'external source id' element. |

--- a/schema/icpsr_study_schema.json
+++ b/schema/icpsr_study_schema.json
@@ -337,7 +337,7 @@
         "type": "string"
       },
       "controlledVocab": "N/A",
-      "icpsrGuidance": "This is an internal ICPSR element that is not publicly displayed.",
+      "icpsrGuidance": "This is an internal ICPSR element that is not publicly displayed. An External Source ID consists of: an ICPSR-defined source organization code, a colon, and a Depositor-supplied ID.",
       "examples": [ 
         ["BJS:271"],
         ["PSC:12345"]


### PR DESCRIPTION
Included additional information from Metadata Editor version history: "An External Source ID consists of: an ICPSR-defined source organization code, a colon, and a Depositor-supplied ID."